### PR TITLE
 Automatically fill in the 'name' parameter when using the logHours command

### DIFF
--- a/main.js
+++ b/main.js
@@ -63,6 +63,10 @@ async function init() {
 
     switch (tokens[0].toLowerCase()) {
       case '!loghours':
+        if (tokens.length === 3) {
+            tokens.splice(1, 0, message.author.tag); // 'name' is the Discord 'tag' (e.g. hydrabolt#0001)
+        }
+      
         if (tokens.length !== 4) {
           message.reply('Sorry, I didn\'t understand you. Please try again?\n' +
             'Here\'s the format I understand:\n' +

--- a/main.js
+++ b/main.js
@@ -61,8 +61,8 @@ async function init() {
 
     const tokens = message.content.trim().split(/\s+/g);
 
-    switch (tokens[0]) {
-      case '!logHours':
+    switch (tokens[0].toLowerCase()) {
+      case '!loghours':
         if (tokens.length !== 4) {
           message.reply('Sorry, I didn\'t understand you. Please try again?\n' +
             'Here\'s the format I understand:\n' +


### PR DESCRIPTION
This makes the 'name' parameter for logHours optional

`logHours <your-name> <description> <hours>` can be `logHours <description> <hours>`

Uses your discord tag as the name (e.g. `hydrabolt#0001`). This will break (mismatched names) if we have a user with Nitro who changes their four digit suffix but using the discord tag is more human readable (for the spreadsheet) than using a unique id

Other edit I did at the same time is super minor - just made commands case-insensitive using .toLowerCase, shouldn't have any adverse effects