### PR TITLE
 Fixed that a user could log zero hours

### DIFF
--- a/volunteers.js
+++ b/volunteers.js
@@ -79,6 +79,12 @@ module.exports = async function startVolunteers() {
           break;
         }
 
+        if (hours < -24 || hours > 24) {
+          message.reply('I can only add or remove a maximum of 24 hours! ' +
+            'Please try again?\n');
+          break;
+        } 
+        
         try {
           const prevMilestone = await getCurrentMilestone(googleClient);
           await logHours({ googleClient, name, description, hours });

--- a/volunteers.js
+++ b/volunteers.js
@@ -71,25 +71,25 @@ module.exports = async function startVolunteers() {
 
         const name = tokens[1];
         const description = tokens[2];
-        const hours = tokens[3];
 
-        if (isNaN(hours)) {
+        if (isNaN(tokens[3])) {
           message.reply('I couldn\'t figure out how many hours you did. ' +
             'Please try again?\n');
           break;
         }
+        const hours = parseFloat(tokens[3]);
 
         if (Math.abs(hours) > 24) {
           message.reply('I can only add or remove a maximum of 24 hours! ' +
             'Please try again?\n');
           break;
-        } 
+        }
         
-        if (hours == 0) {
+        if (hours === 0) {
           message.reply('Looks like you didn\'t contribute any volunteering time. ' +
             'Please try again once you have!\n');
           break;
-        }  
+        }
         
         try {
           const prevMilestone = await getCurrentMilestone(googleClient);

--- a/volunteers.js
+++ b/volunteers.js
@@ -79,13 +79,13 @@ module.exports = async function startVolunteers() {
           break;
         }
 
-        if (Math.abs(hours)> 24) {
+        if (Math.abs(hours) > 24) {
           message.reply('I can only add or remove a maximum of 24 hours! ' +
             'Please try again?\n');
           break;
         } 
         
-        if (hours === 0) {
+        if (hours == 0) {
           message.reply('Looks like you didn\'t contribute any volunteering time. ' +
             'Please try again once you have!\n');
           break;

--- a/volunteers.js
+++ b/volunteers.js
@@ -79,11 +79,17 @@ module.exports = async function startVolunteers() {
           break;
         }
 
-        if (hours < -24 || hours > 24) {
+        if (Math.abs(hours)> 24) {
           message.reply('I can only add or remove a maximum of 24 hours! ' +
             'Please try again?\n');
           break;
         } 
+        
+        if (hours === 0) {
+          message.reply('Looks like you didn\'t contribute any volunteering time. ' +
+            'Please try again once you have!\n');
+          break;
+        }  
         
         try {
           const prevMilestone = await getCurrentMilestone(googleClient);


### PR DESCRIPTION
This is why we don't use strict equality 😂 (`hours` is a string)

Also I should probably have tested it before merging it but I was sick of George logging zero hours